### PR TITLE
Support the x-forwarded-proto for protocol if present

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -29,7 +29,7 @@ const Request = {
     },
 
     protocol() {
-      return this.connection.encrypted
+      return this.get('x-forwarded-proto') || this.connection.encrypted
         ? 'https'
         : 'http';
     },


### PR DESCRIPTION
If the `X-Forwarded-Proto` header is present, use that for the protocol instead of `req.connection`.